### PR TITLE
[FEAT] 리뷰 댓글CRUD + 인가

### DIFF
--- a/review/response.py
+++ b/review/response.py
@@ -1,126 +1,32 @@
-### Review 생성 관련 Response
-def ReviewCreateSuccessed(data):
-    return {
-        'status': 201,
-        'message': '리뷰 생성 성공',
-        'data': data
-    }
+from typing import Union
 
-def ReviewFailed(err):
-    return {
-        'status': 400,
-        'err_message': err
-    }
-
-def ReviewImageFormatError(err):
-    return {
-        'status': 400,
-        'message': '이미지 파일 오류',
-        'err_message': err
-    }
-
-def ReviewImageUploadError():
-    return {
-        'status': 500,
-        'message': '이미지 s3 업로드 중 오류',
-    }
-
-def ReviewTooManyImages():
-    return {
-        'status': 400,
-        'message': '이미지는 최대 5장까지 가능'
-    }
-
-def ReviewGetListSuccess(data):
-    return {
-        'status': 200,
-        'message': '리뷰 리스트 조회 성공',
-        'data': data
-    }
-
-def ReviewGetListFail():
-    return {
-        'status': 500,
-        'message': '리뷰 리스트 조회 실패',
-    }
+class ResponseDto:
+    def __init__(self, status, msg, data=None):
+        self.status = status
+        self.data = data
+        self.msg = msg
 
 
-
-### Review Detail 관련 Response
-def ReviewDetailGetSuccess(data):
-    return {
-        'status': 200,
-        'message': '리뷰 Detail 조회 성공',
-        'data': data
-    }
-
-def ReviewDetailGetFail():
-    return {
-        'status': 500,
-        'message': '리뷰 Detail 조회 실패',
-    }
-
-def ReviewPutSuccess(data):
-    return {
-        'status': 200,
-        'message': '리뷰 수정 성공',
-        'data': data
-    }
-
-def ReviewDeleteSuccess(rid):
-    return {
-        'status': 204,
-        'message': '리뷰 삭제 성공',
-        'rid': rid
-    }
-
-def ReviewDeleteFail(rid):
-    return {
-        'status': 500,
-        'message': '리뷰 삭제 실패',
-        'rid': rid
-    }
-
-
-### Comment 관련 Response
-def CommentGetSuccess(data):
-    return {
-        'status': 200,
-        'message': '댓글 조회 성공',
-        'data': data
-    }
-
-def CommentCreateSuccess(data):
-    return {
-        'status': 201,
-        'message': '댓글 생성 성공',
-        'data': data
-    }
-
-def CommentCreateFail(err):
-    return {
-        'status': 400,
-        'message': '댓글 생성 실패',
-        'error_message': err
-    }
-
-def CommentDeleteSuccess(cid):
-    return {
-        'status': 204,
-        'message': '댓글 삭제 성공',
-        'rid': cid
-    }
-
-def CommentPutSuccess(data):
-    return {
-        'status': 200,
-        'message': '댓글 수정 성공',
-        'data': data
-    }
-
-def CommentPutFail(err):
-    return {
-        'status': 400,
-        'message': '댓글 수정 실패',
-        'error_message': err
-    }
+message = {
+    # 리뷰 관련
+    "TooManyImages": "이미지는 최대 5장까지 가능",
+    "ImageFormatError": "이미지 파일 저장 불가",
+    "ReviewCreateSuccess": "리뷰 생성 성공",
+    "ReviewPutSuccess": "리뷰 수정 성공",
+    
+    "ReviewListGetSuccess": "리뷰 리스트 조회 성공",
+    "ReviewGetSuccess": "단일 리뷰 조회 성공",
+    "ReviewNotFound": "일치하는 리뷰 없음",
+    
+    "ReviewDeleteSuccess": "리뷰 삭제 성공",
+    
+    
+    # 댓글 관련
+    "CommentGetSuccess": "댓글 조회 성공",
+    "CommentCreateSuccess": "댓글 생성 성공",
+    "CommentPutSuccess": "댓글 수정 성공",
+    "CommentDeleteSuccess": "댓글 삭제 성공",
+    
+    "InvalidFormat": "올바르지 않은 형식",
+    
+}

--- a/review/s3_manager.py
+++ b/review/s3_manager.py
@@ -1,0 +1,49 @@
+from config import settings
+import boto3
+from botocore.exceptions import ClientError
+
+
+# S3에 이미지 저장
+def save_image_s3(image, rid):
+    try:
+        s3 = boto3.client('s3',
+                          aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                          aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                          region_name=settings.AWS_REGION)
+        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+        
+        file_path = image.name
+        s3.upload_fileobj(image, bucket_name, file_path)
+        s3_url = f"https://{settings.AWS_S3_CUSTOM_DOMAIN}/{rid}/{file_path}"
+        return s3_url
+        
+    except:
+        print("s3 이미지 업로드 불가")
+        return None
+
+
+# s3 이미지 삭제
+def delete_image_s3(image_url):
+    try:
+        s3 = boto3.client('s3',
+                          aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                          aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                          region_name=settings.AWS_REGION)
+        
+        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+        image_key = image_url.split(settings.AWS_S3_CUSTOM_DOMAIN + '/')[1]
+        
+        # 이미지 존재 여부 확인
+        try:
+            s3.head_object(Bucket=bucket_name, Key=image_key)
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                print("이미지가 존재하지 않습니다.")
+                return
+        
+        # 이미지 삭제
+        s3.delete_object(Bucket=bucket_name, Key=image_key)
+        print("S3 이미지 삭제 성공")
+        
+    except:
+        print("S3 이미지 삭제 실패")

--- a/review/service.py
+++ b/review/service.py
@@ -6,29 +6,62 @@ from .response import *
 from .serializers import *
 
 
-### Review save 관련 메소드
-def save_review(request, review):
+### 리뷰 관련 메소드
+# 리뷰 생성/수정 메소드
+def save_review(request, review) -> ResponseDto:
     images = request.data.getlist('images', [])  # 기본 값을 빈 리스트로 지정
     if len(images[0]) == 0:     # 자동으로 ['']이 들어가기 때문에 한번 더 체크
         images = []
     elif len(images) > 5:
-        return JsonResponse(ReviewTooManyImages(), status=400)
+        return ResponseDto(status=400, msg=message["TooManyImages"])
     
-    request.data['writer'] = request.user.id    # 현재 로그인된 user를 writer로
+    mutable_data = request.data.copy()
+    mutable_data['writer'] = request.user.id    # 현재 로그인된 user를 writer로
     
     if review is None:
-        serializer = ReviewSerializer(data=request.data)    # post인 경우 새로운 review 생성
+        serializer = ReviewSerializer(data=mutable_data)    # post인 경우 새로운 review 생성
     else:
-        serializer = ReviewSerializer(review, data=request.data) # put인 경우 기존의 review를 수정
+        serializer = ReviewSerializer(review, data=mutable_data) # put인 경우 기존의 review를 수정
     
     if not serializer.is_valid():
-        return JsonResponse(serializer.errors, status=400)
+        return ResponseDto(status=400, msg=serializer.errors)
     review_instance = serializer.save()     # review를 DB에 저장
     s3_urls = save_images_db(images, review_instance.rid)   # image를 DB에 저장
     
-    review_serializer_data = serializer.data
-    review_serializer_data["images"] = s3_urls
-    return review_serializer_data
+    if s3_urls is None:
+        return ResponseDto(status=400, msg=message['ImageFormatError'])
+    
+    data = serializer.data
+    data["images"] = s3_urls
+    if review is None:
+        return ResponseDto(status=201, data=data, msg=message['ReviewCreateSuccess'])
+    else:
+        return ResponseDto(status=200, data=data, msg=message['ReviewPutSuccess'])
+
+
+# 리뷰 리스트 조회
+def get_review_list() -> ResponseDto:
+    review_list = []
+    reviews = Review.objects.all()
+    for review in reviews:
+        images = Image.objects.filter(review__rid=review.rid)
+        review_data = ReviewSerializer(review).data
+        review_data["images"] = [image.image.url for image in images]
+        review_list.append(review_data)
+    return ResponseDto(status=200, data=review_list, msg=message['ReviewListGetSuccess'])
+
+
+# 단일 리뷰 조회
+def get_one_review(rid) -> ResponseDto:
+    try:
+        review = Review.objects.get(rid=rid)
+        images = Image.objects.filter(review__rid=rid)
+        review_data = ReviewSerializer(review).data
+        review_data["images"] = [image.image.url for image in images]
+        return ResponseDto(status=200, data=review_data, msg=message['ReviewGetSuccess'])
+    except Review.DoesNotExist:
+        return ResponseDto(status=404, msg=message['ReviewNotFound'])
+
 
 
 def save_image_s3(image, rid):      # S3에 이미지 저장
@@ -45,17 +78,52 @@ def save_image_s3(image, rid):      # S3에 이미지 저장
         return s3_url
         
     except:
-        return Exception("s3 이미지 업로드 실패")
-
+        print("s3 이미지 업로드 불가")
+        return None
 
 def save_images_db(images, rid):
     s3_urls = []
     for image in images:
         image_serializer = ImageSerializer(data={"image": image, "review":rid})
         if not image_serializer.is_valid():
-            return JsonResponse(ReviewImageFormatError(image_serializer.errors), status=400)
+            print("이미지 형식이 아님")
+            return None
+        
         s3_url = save_image_s3(image, rid)
+        if s3_url is None:
+            return None
+        
         s3_urls.append(s3_url)
         image_serializer.validated_data["image"] = s3_url
         image_serializer.save()
     return s3_urls
+
+
+
+
+### 댓글 관련 메소드
+def get_comment(rid) -> ResponseDto:
+    try:
+        review = Review.objects.get(rid=rid)
+        comments = Comment.objects.filter(review=review)
+        serializer = CommentSerializer(comments, many=True)
+        return ResponseDto(status=200, data=serializer.data, msg=message['CommentGetSuccess'])
+    except Review.DoesNotExist:
+        return ResponseDto(status=404, msg=message['ReviewNotFound'])
+
+def save_comment(request, rid, comment):
+    request.data['review'] = rid
+    request.data['writer'] = request.user.id    # 현재 로그인된 user
+    
+    if comment is None:     # post일 때
+        serializer = CommentSerializer(data=request.data)
+    else:   # put일 때
+        serializer = CommentSerializer(comment, data=request.data)
+    
+    if serializer.is_valid():
+        serializer.save()
+        if comment is None:
+            return ResponseDto(status=201, data=serializer.data, msg=message['CommentCreateSuccess'])
+        else:
+            return ResponseDto(status=200, data=serializer.data, msg=message['CommentPutSuccess'])
+    return ResponseDto(status=400, msg=message['InvalidFormat'])

--- a/review/service.py
+++ b/review/service.py
@@ -1,14 +1,11 @@
-from config import settings
-import boto3
-from django.http import JsonResponse
-
 from .response import *
 from .serializers import *
+from .s3_manager import *
 
 
 ### 리뷰 관련 메소드
-# 리뷰 생성/수정 메소드
-def save_review(request, review) -> ResponseDto:
+# 리뷰 생성
+def post_review(request) -> ResponseDto:
     images = request.data.getlist('images', [])  # 기본 값을 빈 리스트로 지정
     if len(images[0]) == 0:     # 자동으로 ['']이 들어가기 때문에 한번 더 체크
         images = []
@@ -17,11 +14,7 @@ def save_review(request, review) -> ResponseDto:
     
     mutable_data = request.data.copy()
     mutable_data['writer'] = request.user.id    # 현재 로그인된 user를 writer로
-    
-    if review is None:
-        serializer = ReviewSerializer(data=mutable_data)    # post인 경우 새로운 review 생성
-    else:
-        serializer = ReviewSerializer(review, data=mutable_data) # put인 경우 기존의 review를 수정
+    serializer = ReviewSerializer(data=mutable_data)
     
     if not serializer.is_valid():
         return ResponseDto(status=400, msg=serializer.errors)
@@ -33,10 +26,36 @@ def save_review(request, review) -> ResponseDto:
     
     data = serializer.data
     data["images"] = s3_urls
-    if review is None:
-        return ResponseDto(status=201, data=data, msg=message['ReviewCreateSuccess'])
-    else:
-        return ResponseDto(status=200, data=data, msg=message['ReviewPutSuccess'])
+    return ResponseDto(status=201, data=data, msg=message['ReviewCreateSuccess'])
+
+
+# 리뷰 수정
+def put_review(request, review) -> ResponseDto:
+    images = request.data.getlist('images', [])  # 기본 값을 빈 리스트로 지정
+    if len(images[0]) == 0:     # 자동으로 ['']이 들어가기 때문에 한번 더 체크
+        images = []
+    elif len(images) > 5:
+        return ResponseDto(status=400, msg=message["TooManyImages"])
+    
+    mutable_data = request.data.copy()
+    mutable_data['writer'] = request.user.id    # 현재 로그인된 user를 writer로
+    serializer = ReviewSerializer(review, data=mutable_data)
+    
+    if not serializer.is_valid():
+        return ResponseDto(status=400, msg=serializer.errors)
+    review_instance = serializer.save()     # review를 DB에 저장
+    
+    print(mutable_data['images'])
+    delete_image_s3(mutable_data['images'])
+    s3_urls = save_images_db(images, review_instance.rid)   # image를 DB에 저장
+    
+    if s3_urls is None:
+        return ResponseDto(status=400, msg=message['ImageFormatError'])
+    
+    data = serializer.data
+    data["images"] = s3_urls
+    return ResponseDto(status=200, data=data, msg=message['ReviewPutSuccess'])
+
 
 
 # 리뷰 리스트 조회
@@ -63,24 +82,6 @@ def get_one_review(rid) -> ResponseDto:
         return ResponseDto(status=404, msg=message['ReviewNotFound'])
 
 
-
-def save_image_s3(image, rid):      # S3에 이미지 저장
-    try:
-        s3 = boto3.client('s3',
-                          aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                          aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-                          region_name=settings.AWS_REGION)
-        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
-        
-        file_path = image.name
-        s3.upload_fileobj(image, bucket_name, file_path)
-        s3_url = f"https://{settings.AWS_S3_CUSTOM_DOMAIN}/{rid}/{file_path}"
-        return s3_url
-        
-    except:
-        print("s3 이미지 업로드 불가")
-        return None
-
 def save_images_db(images, rid):
     s3_urls = []
     for image in images:
@@ -97,7 +98,6 @@ def save_images_db(images, rid):
         image_serializer.validated_data["image"] = s3_url
         image_serializer.save()
     return s3_urls
-
 
 
 

--- a/review/service.py
+++ b/review/service.py
@@ -13,7 +13,11 @@ def save_review(request):
     elif len(images) > 5:
         return JsonResponse(ReviewTooManyImages(), status=400)
     
+    request.data['writer'] = request.user.id    # 현재 로그인된 user
     review_serializer = ReviewSerializer(data=request.data)
+    if not review_serializer.is_valid():
+        return JsonResponse(review_serializer.errors, status=400)
+    
     review_instance = save_review_instance(review_serializer)
     s3_urls = save_images_db(images, review_instance.rid)
     
@@ -28,7 +32,11 @@ def put_review(request, review):
     elif len(images) > 5:
         return JsonResponse(ReviewTooManyImages(), status=400)
     
+    request.data['writer'] = request.user.id    # 현재 로그인된 user
     review_serializer = ReviewSerializer(review, data=request.data) # 기존의 review를 수정
+    if not review_serializer.is_valid():
+        return JsonResponse(review_serializer.errors, status=400)
+    
     review_instance = save_review_instance(review_serializer)
     s3_urls = save_images_db(images, review_instance.rid)
     

--- a/review/views.py
+++ b/review/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from requests import Response
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from config.permissions import IsWriterOrReadOnly
@@ -12,73 +13,61 @@ from .response import *
 from .service import *
 
 
+def responseFactory(res: ResponseDto):
+    if res.data is None:
+        return JsonResponse(
+            status=res.status,
+            data={
+                "msg": res.msg
+            }
+        )
+    else:
+        return JsonResponse(
+            status=res.status,
+            data={
+                "msg": res.msg,
+                "data": res.data
+            }
+        )
+
+
 # 나중에 로그인한 유저로 자동 writer 추가
 class ReviewList(APIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
     
     @transaction.atomic     # 오류 생기면 롤백
     def post(self, request):
-        try:
-            review_serializer_data = save_review(request, None)
-            if isinstance(review_serializer_data, JsonResponse):
-                response = review_serializer_data
-                raise Exception()
-            response = JsonResponse(ReviewCreateSuccessed(review_serializer_data), status=201)
-        except:
+        res = save_review(request, None)
+        if res.status >= 400:
             transaction.set_rollback(True)
-        finally:
-            return response
+        return responseFactory(res)
     
     def get(self, request):
-        try:
-            review_lists = []
-            reviews = Review.objects.all()
-            for review in reviews:
-                images = Image.objects.filter(review__rid=review.rid)
-                review_data = ReviewSerializer(review).data
-                review_data["images"] = [image.image.url for image in images]
-                review_lists.append(review_data)
-            
-            return JsonResponse(ReviewGetListSuccess(review_lists), status=200)
-        except:
-            return JsonResponse(ReviewGetListFail(), status=500)
+        data = get_review_list()
+        return responseFactory(data)
 
 
 class ReviewDetail(APIView):
     permission_classes = [IsWriterOrReadOnly]
     
     def get(self, request, rid):
-        try:
-            review = get_object_or_404(Review, rid=rid)
-            images = Image.objects.filter(review__rid=rid)
-            review_data = ReviewSerializer(review).data
-            review_data["images"] = [image.image.url for image in images]
-            return JsonResponse(ReviewDetailGetSuccess(review_data), status=200)
-        except:
-            return JsonResponse(ReviewDetailGetFail(), status=500)
-
+        data = get_one_review(rid)
+        return responseFactory(data)
     
     @transaction.atomic     # 오류 생기면 롤백
     def put(self, request, rid):
         review = get_object_or_404(Review, rid=rid)
-        self.check_object_permissions(self.request, review)
-        try:
-            review_serializer_data = save_review(request, review)
-            if isinstance(review_serializer_data, JsonResponse):
-                response = review_serializer_data
-                raise Exception()
-            response = JsonResponse(ReviewPutSuccess(review_serializer_data), status=200)
-        except:
+        self.check_object_permissions(self.request, review) # 인가 체크
+        res = save_review(request, review)
+        if res.status >= 400:
             transaction.set_rollback(True)
-        finally:
-            return response
-
+        return responseFactory(res)
 
     def delete(self, request, rid):
         review = get_object_or_404(Review, rid=rid)
         self.check_object_permissions(self.request, review)
         review.delete()
-        return JsonResponse(ReviewDeleteSuccess(rid), status=204)
+        return JsonResponse(status=204, data={"msg": message['ReviewDeleteSuccess']})
 
 
 
@@ -87,19 +76,12 @@ class CommentList(APIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
     
     def get(self, request, rid):
-        review = get_object_or_404(Review, rid=rid)
-        comments = Comment.objects.filter(review=review)
-        serializer = CommentSerializer(comments, many=True)
-        return JsonResponse(CommentGetSuccess(serializer.data), status=200)
+        data = get_comment(rid)
+        return responseFactory(data)
 
     def post(self, request, rid):
-        request.data['review'] = rid
-        request.data['writer'] = request.user.id    # 현재 로그인된 user
-        serializer = CommentSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return JsonResponse(CommentCreateSuccess(serializer.data), status=201)
-        return JsonResponse(CommentCreateFail(serializer.errors), status=400)
+        res = save_comment(request, rid, None)
+        return responseFactory(res)
 
 
 class CommentDetail(APIView):
@@ -108,19 +90,11 @@ class CommentDetail(APIView):
     def put(self, request, rid, cid):
         comment = get_object_or_404(Comment, cid=cid)
         self.check_object_permissions(self.request, comment)
-        
-        request.data['cid'] = comment.cid
-        request.data['writer'] = request.user.id    # 현재 로그인된 user
-        request.data['review'] = rid
-        
-        serializer = CommentSerializer(comment, data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return JsonResponse(CommentPutSuccess(serializer.data), status=201)
-        return JsonResponse(CommentPutFail(serializer.errors), status=400)
+        res = save_comment(request, rid, comment)
+        return responseFactory(res)
     
     def delete(self, request, rid, cid):
         comment = get_object_or_404(Comment, cid=cid)
         self.check_object_permissions(self.request, comment)
         comment.delete()
-        return JsonResponse(CommentDeleteSuccess(cid), status=204)
+        return JsonResponse(status=204, data={'msg': message['CommentDeleteSuccess']})

--- a/review/views.py
+++ b/review/views.py
@@ -19,7 +19,7 @@ class ReviewList(APIView):
     @transaction.atomic     # 오류 생기면 롤백
     def post(self, request):
         try:
-            review_serializer_data = save_review(request)
+            review_serializer_data = save_review(request, None)
             if isinstance(review_serializer_data, JsonResponse):
                 response = review_serializer_data
                 raise Exception()
@@ -63,13 +63,14 @@ class ReviewDetail(APIView):
         review = get_object_or_404(Review, rid=rid)
         self.check_object_permissions(self.request, review)
         try:
-            review_serializer_data = put_review(request, review)
+            review_serializer_data = save_review(request, review)
             if isinstance(review_serializer_data, JsonResponse):
                 response = review_serializer_data
                 raise Exception()
-            return JsonResponse(ReviewPutSuccess(review_serializer_data), status=200)
+            response = JsonResponse(ReviewPutSuccess(review_serializer_data), status=200)
         except:
             transaction.set_rollback(True)
+        finally:
             return response
 
 

--- a/review/views.py
+++ b/review/views.py
@@ -37,7 +37,7 @@ class ReviewList(APIView):
     
     @transaction.atomic     # 오류 생기면 롤백
     def post(self, request):
-        res = save_review(request, None)
+        res = post_review(request)
         if res.status >= 400:
             transaction.set_rollback(True)
         return responseFactory(res)
@@ -58,7 +58,8 @@ class ReviewDetail(APIView):
     def put(self, request, rid):
         review = get_object_or_404(Review, rid=rid)
         self.check_object_permissions(self.request, review) # 인가 체크
-        res = save_review(request, review)
+        res = put_review(request, review)
+        
         if res.status >= 400:
             transaction.set_rollback(True)
         return responseFactory(res)


### PR DESCRIPTION
## PR Point
<!-- 공유하고 싶은 부분, 작업 내용 등 -->
- 댓글 CRUD 작업했습니다
- 로그인한 사람만 post, 글쓴이만 put, delete 할 수 있도록 `permission_classes`를 추가했습니다
    - 글쓴이만 접근 가능하도록 커스텀 permission인 `IsWriterOrReadOnly` 를 만들었는데 장고가 커스텀한 권한은 검사를 안하더라구요...? `self.check_object_permissions` 코드로 수동으로 체크해주었습ㄴ디ㅏ
- S3 관련 메소드들은 s3_manager.py 파일로 분리했습니다
- 코드 리팩토링
    - 기존의 response.py가 하드코딩이 많은 것 같아서 `ResponseDto`를 만들었습니다
    (Dto: 데이터의 구조화와 전달을 위해서 사용하는 Data Transfer Object)
    - service.py의 메소드들은 반드시 ResponseDto 형식으로 반환 -> views.py에서는 받은 ResponseDto를 responseFactory를 통해 결과 반환
    - 바뀐 코드가 너무 많아서 그냥 파일로 보는게 더 편할거에요..

## Screenshot
access token을 넣지 않으면 post, put, delete에 접근 불가능
![image](https://github.com/DowaDream/DowaDream-Server/assets/71963320/7ad83bdb-8421-4a13-9fc6-8cea8557f63b)


## Issue
- Resolved: #11 

## Reference
- custom permission 적용 안되는 이슈: https://velog.io/@ready2start/DRF-Custom-Permission-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0
- 비즈니스 로직 분리: https://jay-ji.tistory.com/75

## Etc
사실 review 관련해서 작업할 부분이 남아있는데 바뀐 코드가 많아서 코드리뷰하기 힘들까봐 한번 끊었습니다! 
