### PR TITLE
[FEAT] 후기 추가 API

### DIFF
--- a/review/response.py
+++ b/review/response.py
@@ -14,8 +14,9 @@ message = {
     "ReviewCreateSuccess": "리뷰 생성 성공",
     "ReviewPutSuccess": "리뷰 수정 성공",
     
-    "ReviewListGetSuccess": "전체 리뷰 리스트 조회 성공",
+    "AllReviewListGetSuccess": "전체 리뷰 리스트 조회 성공",
     "ReviewListInProgramGetSuccess": "특정 봉사의 리뷰 리스트 조회 성공",
+    "UserReviewListGetSuccess": "사용자 리뷰 리스트 조회 성공",
     "ReviewGetSuccess": "단일 리뷰 조회 성공",
     "ReviewNotFound": "일치하는 리뷰 없음",
     

--- a/review/review_service.py
+++ b/review/review_service.py
@@ -55,7 +55,7 @@ def put_review(request, review) -> ResponseDto:
     return ResponseDto(status=200, data=data, msg=message['ReviewPutSuccess'])
 
 
-def get_review_list() -> ResponseDto:
+def get_all_review_list() -> ResponseDto:
     review_list = []
     reviews = Review.objects.all()
     for review in reviews:
@@ -64,6 +64,12 @@ def get_review_list() -> ResponseDto:
         review_data["images"] = [image.image.url for image in images]
         review_list.append(review_data)
     return ResponseDto(status=200, data=review_list, msg=message['AllReviewListGetSuccess'])
+
+
+def get_user_review_list(user) -> ResponseDto:
+    reviews = Review.objects.filter(writer=user)  # 해당 유저가 쓴 리뷰들 가져오기
+    serializer = ReviewSerializer(reviews, many=True)  # Review 객체들을 직렬화
+    return ResponseDto(status=200, data=serializer.data, msg=message['UserReviewListGetSuccess'])
 
 
 def get_review_list_in_progrm(progrmRegistNo) -> ResponseDto:

--- a/review/review_service.py
+++ b/review/review_service.py
@@ -63,7 +63,7 @@ def get_review_list() -> ResponseDto:
         review_data = ReviewSerializer(review).data
         review_data["images"] = [image.image.url for image in images]
         review_list.append(review_data)
-    return ResponseDto(status=200, data=review_list, msg=message['ReviewListGetSuccess'])
+    return ResponseDto(status=200, data=review_list, msg=message['AllReviewListGetSuccess'])
 
 
 def get_review_list_in_progrm(progrmRegistNo) -> ResponseDto:

--- a/review/urls.py
+++ b/review/urls.py
@@ -2,9 +2,11 @@ from django.urls import path
 from .views import *
 
 urlpatterns = [
-    path('', ReviewList.as_view()),
+    path('', UserReviewList.as_view()),
     
-    path('<int:rid>/', ReviewDetail.as_view()),
+    path('<int:rid>/', UserReviewDetail.as_view()),
     path('<int:rid>/comment/', CommentList.as_view()),
     path('<int:rid>/comment/<int:cid>/', CommentDetail.as_view()),
+    
+    path('user/', get_user_reviews),
 ]

--- a/review/views.py
+++ b/review/views.py
@@ -31,14 +31,12 @@ def responseFactory(res: ResponseDto):
 
 
 ### Review ###
-# (사용자, 봉사 관계없이) 모든 리뷰를 반환
+# 로그인한 사용자의 리뷰 리스트 반환
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def get_user_reviews(request):
     user = request.user  # 로그인한 사용자 정보 가져오기
-    reviews = Review.objects.filter(writer=user)  # 해당 유저가 쓴 리뷰들 가져오기
-    serializer = ReviewSerializer(reviews, many=True)  # Review 객체들을 직렬화
-    res = ResponseDto(status=200, data=serializer.data, msg=message['UserReviewListGetSuccess'])
+    res = get_user_review_list(user)
     return responseFactory(res)
 
 
@@ -55,7 +53,7 @@ class UserReviewList(APIView):
     def get(self, request):
         progrmRegistNo = request.GET.get('progrmRegistNo')
         if progrmRegistNo is None:
-            data = get_review_list()
+            data = get_all_review_list()
         else:
             data = get_review_list_in_progrm(progrmRegistNo)
         return responseFactory(data)


### PR DESCRIPTION
## PR Point
<!-- 공유하고 싶은 부분, 작업 내용 등 -->
- 후기 리스트 조회 1) `/reviews`: 전체 리뷰 리스트 조회
- 후기 리스트 조회 2) `/reviews/user`: 특정 유저의 리뷰 리스트 조회
- 후기 리스트 조회 3) `/reviews/?progrmRegistNo=xx`: 특정 봉사의 리뷰 리스트 조회
이렇게 후기 리스트 조회를 3가지로 나눴습니다

## Screenshot
![image](https://github.com/DowaDream/DowaDream-Server/assets/71963320/b5cbd654-cf32-4546-a51d-0eb2dce712de)


## Issue
- Resolved: #21 

## Reference
- RESTful design: https://velog.io/@gga4638/REST-API-URI-%EB%94%94%EC%9E%90%EC%9D%B8-%EA%B7%9C%EC%B9%99
