### PR TITLE
[FEAT] 응원하기순 봉사 추천

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -101,7 +101,7 @@ REST_FRAMEWORK = {
 REST_USE_JWT = True
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(hours=3),    # 유효기간 3시간
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=3),    # 유효기간 3일
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),    # 유효기간 7일
     'ROTATE_REFRESH_TOKENS': False,
     'BLACKLIST_AFTER_ROTATION': False,

--- a/program/dto.py
+++ b/program/dto.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 class ProgramDto:
     def __init__(self, tagName, title, registerInstitute, recruitStart, recruitEnd, actStart, actEnd):
-        self.tag = tagName.split()[0]
+        self.tag = tagName.split()[0]   # 태그(대분류)
         self.title = title  # 봉사 제목
         self.registerInstitute = registerInstitute  # 등록 기관
         self.recruitStart = recruitStart    # 모집 시작일

--- a/program/dto.py
+++ b/program/dto.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+
+class ProgramDto:
+    def __init__(self, tagName, title, registerInstitute, recruitStart, recruitEnd, actStart, actEnd):
+        self.tag = tagName.split()[0]
+        self.title = title  # 봉사 제목
+        self.registerInstitute = registerInstitute  # 등록 기관
+        self.recruitStart = recruitStart    # 모집 시작일
+        self.recruitEnd = recruitEnd    # 모집 종료일
+        self.actStart = actStart    # 봉사 시작일
+        self.actEnd = actEnd    # 봉사 종료일
+        self.dday = self.calculate_d_day(recruitEnd)    # 디데이
+    
+    def calculate_d_day(self, date):
+        try:
+            date = datetime.strptime(date, '%Y/%m/%d')  # 문자열을 파싱하여 datetime 객체로 변환
+            today = datetime.now()
+            d_day = (date - today).days
+            return d_day
+        except ValueError:
+            # 날짜 문자열 파싱 오류 처리
+            return None
+    
+    
+    def to_json(self):
+        return {
+            "tag": self.tag,
+            "title": self.title,
+            "registerInstitute": self.registerInstitute,
+            "recruitStart": self.recruitStart,
+            "recruitEnd": self.recruitEnd,
+            "actStart": self.actStart,
+            "actEnd": self.actEnd,
+            "dday": self.dday
+        }

--- a/program/response.py
+++ b/program/response.py
@@ -7,6 +7,8 @@ class ResponseDto:
 
 
 message = {
+    "PrgrmRecommendCheer": "봉사 추천: 응원순 조회 성공",
+    
     "PrgmInteractSuccess": "봉사내역/스크랩/응원하기 상태 업데이트 성공",
     "PrgmInteractFail": "봉사내역/스크랩/응원하기 상태 업데이트 실패",
     

--- a/program/search_service.py
+++ b/program/search_service.py
@@ -1,0 +1,144 @@
+import requests
+import xmltodict
+from django.conf import settings
+from django.http import JsonResponse
+from user.models import User
+
+def callByKeyword(keyword, actPlace=None):
+    url = 'http://openapi.1365.go.kr/openapi/service/rest/VolunteerPartcptnService/getVltrSearchWordList'
+    params = {
+        'keyword' : keyword,
+        'schCateGu' : 'all',
+        'actPlace' : actPlace
+        }
+    response = requests.get(url, params=params)
+    parsed_xml = xmltodict.parse(response.text)
+
+    # myjson = json.dumps(parsed_xml,ensure_ascii = False)
+    # print(myjson)
+
+    if parsed_xml["response"]["header"]["resultCode"] == "00":
+        result = []
+        itemsList = parsed_xml["response"]["body"]["items"]
+        if itemsList is None:
+            return None
+        items = itemsList['item']
+        # 게시물이 여러개일 때는 items가 list인데, 하나일 때는 dict이기 때문에 분기를 나누어 처리
+        if type(items) is dict:
+            temp = {}
+            temp['title'] = items['progrmSj']
+            temp['place'] = items['actPlace']
+            temp['progrmRegistNo'] = items['progrmRegistNo']
+
+            result.append(temp)
+        # print(items)
+        else:
+            for item in items:
+                temp = {}
+                temp['title'] = item.get('progrmSj')
+                temp['place'] = item.get('actPlace')
+                temp['progrmRegistNo'] = item.get('progrmRegistNo')
+
+                result.append(temp)
+        # print(result)
+        return result
+    else:
+        return None
+
+def callByArea(keyword):
+    url = 'http://openapi.1365.go.kr/openapi/service/rest/VolunteerPartcptnService/getVltrAreaList'
+    params = {
+    'serviceKey' : settings.VOL_API_KEY,
+    'schCateGu' : 'all',
+    'schSign1' : keyword, # 지역코드 (구군)    
+    }
+    # 시도 단위로 검색하려면, schSign1 대신
+    # 'schSido' : keyword # 지역코드(시도)
+
+
+    response = requests.get(url, params=params)
+    parsed_xml = xmltodict.parse(response.text)
+    # myjson = json.dumps(parsed_xml,ensure_ascii = False)
+    # print(myjson)
+    if parsed_xml["response"]["header"]["resultCode"] == "00":
+        result = []
+        itemsList = parsed_xml["response"]["body"]["items"]
+        if itemsList is None:
+            return None
+        items = itemsList['item']
+        if type(items) is dict:
+            temp = {}
+            temp['title'] = items['progrmSj']
+            temp['progrmRegistNo'] = items['progrmRegistNo']
+            result.append(temp)
+
+        for item in items:
+            temp = {}
+            title = item.get('progrmSj')
+            # 놀랍게도 장소 정보를 제공하지 않아, 등록번호로 검색해야 한다
+            # 하지만 API call 개수가 너무 많으면 로딩이 느려지므로 일단은 장소 정보 없이 제공
+            # 향후 필요할 경우 callByRegistNo 함수를 이용해 장소 정보를 가져옴
+            progrmRegistNo = item.get('progrmRegistNo')
+
+            temp['title'] = title
+            temp['progrmRegistNo'] = progrmRegistNo
+            result.append(temp)
+        return result
+    else:
+        return None
+
+def callByRegistNo(registNo):
+    url = 'http://openapi.1365.go.kr/openapi/service/rest/VolunteerPartcptnService/getVltrPartcptnItem'
+    params ={
+        'serviceKey' : settings.VOL_API_KEY,
+        'progrmRegistNo' : registNo
+    }
+    response = requests.get(url, params=params)
+    parsed_xml = xmltodict.parse(response.text)
+    # myjson = json.dumps(parsed_xml,ensure_ascii = False)
+    # print(myjson)
+
+    # print(list(parsed_xml['response'].keys()))
+
+    if parsed_xml["response"]["header"]["resultCode"] == "00":
+        tempVarForNoneCheck = parsed_xml["response"]["body"]["items"]
+        if tempVarForNoneCheck is None:
+            return None
+        item = tempVarForNoneCheck["item"]
+
+        temp = {}
+
+        # 날짜와 시간 값 먼저 처리하기
+        actStartDate = item.get('progrmBgnde')
+        actStartTime = item.get('actBeginTm')
+        # print(f"actStartDate: {actStartDate}, actStartTime: {actStartTime}")
+        actEndDate = item.get('progrmEndde')
+        actEndTime = item.get('actEndTm')
+        # print(f"actEndDate: {actEndDate}, actEndTime: {actEndTime}")
+        actStart = actStartDate[0:4] + '/' + actStartDate[4:6] + '/' + actStartDate[6:8] + '-' + actStartTime + ':00:00'
+        actEnd = actEndDate[0:4] + '/' + actEndDate[4:6] + '/' + actEndDate[6:8] + '-' + actEndTime + ':00:00'
+        tempRecruitStart = item.get('noticeBgnde')
+        tempRecruitEnd = item.get('noticeEndde')
+        recruitStart = tempRecruitStart[0:4] + '/' + tempRecruitStart[4:6] + '/' + tempRecruitStart[6:8]
+        recruitEnd = tempRecruitEnd[0:4] + '/' + tempRecruitEnd[4:6] + '/' + tempRecruitEnd[6:8]
+
+        # 값 가져오기
+        temp['title'] = item.get('progrmSj')
+        temp['recruitStatusNm'] = item.get('progrmSttusSe')
+        temp['actStart'] = actStart
+        temp['actEnd'] = actEnd
+        temp['place'] = item.get('actPlace')
+        temp['adultAble'] = item.get('adultPosblAt')
+        temp['teenAble'] = item.get('yngbgsPosblAt')
+        temp['recruitStart'] = recruitStart
+        temp['recruitEnd'] = recruitEnd
+        temp['recruitInstitute'] = item.get('mnnstNm')
+        temp['registerInstitute'] = item.get('nanmmbyNm')
+        temp['maxPerson'] = item.get('rcritNmpr')
+        temp['content']= item.get('progrmCn')
+        temp['progrmRegistNo'] = registNo
+        temp['tagName']= item.get('srvcClCode')
+
+        return temp
+    else:
+        return None

--- a/program/service.py
+++ b/program/service.py
@@ -1,13 +1,10 @@
-import requests
-import xmltodict
-from django.conf import settings
-from django.http import JsonResponse
-from user.models import User
 from django.db.models import Count
 
 from .response import *
 from .models import *
 from .serializers import *
+from .dto import ProgramDto
+from .search_service import *
 
 
 def update_progrm_interact(data, user) -> ResponseDto:
@@ -45,145 +42,14 @@ def get_interactions_list(user, field_name):
     return interations_list
 
 
-
-
-
-
-def callByKeyword(keyword, actPlace=None):
-    url = 'http://openapi.1365.go.kr/openapi/service/rest/VolunteerPartcptnService/getVltrSearchWordList'
-    params = {
-        'keyword' : keyword,
-        'schCateGu' : 'all',
-        'actPlace' : actPlace
-        }
-    response = requests.get(url, params=params)
-    parsed_xml = xmltodict.parse(response.text)
-
-    # myjson = json.dumps(parsed_xml,ensure_ascii = False)
-    # print(myjson)
-
-    if parsed_xml["response"]["header"]["resultCode"] == "00":
-        result = []
-        itemsList = parsed_xml["response"]["body"]["items"]
-        if itemsList is None:
-            return None
-        items = itemsList['item']
-        # 게시물이 여러개일 때는 items가 list인데, 하나일 때는 dict이기 때문에 분기를 나누어 처리
-        if type(items) is dict:
-            temp = {}
-            temp['title'] = items['progrmSj']
-            temp['place'] = items['actPlace']
-            temp['progrmRegistNo'] = items['progrmRegistNo']
-
-            result.append(temp)
-        # print(items)
-        else:
-            for item in items:
-                temp = {}
-                temp['title'] = item.get('progrmSj')
-                temp['place'] = item.get('actPlace')
-                temp['progrmRegistNo'] = item.get('progrmRegistNo')
-
-                result.append(temp)
-        # print(result)
-        return result
-    else:
-        return None
-
-def callByArea(keyword):
-    url = 'http://openapi.1365.go.kr/openapi/service/rest/VolunteerPartcptnService/getVltrAreaList'
-    params = {
-    'serviceKey' : settings.VOL_API_KEY,
-    'schCateGu' : 'all',
-    'schSign1' : keyword, # 지역코드 (구군)    
-    }
-    # 시도 단위로 검색하려면, schSign1 대신
-    # 'schSido' : keyword # 지역코드(시도)
-
-
-    response = requests.get(url, params=params)
-    parsed_xml = xmltodict.parse(response.text)
-    # myjson = json.dumps(parsed_xml,ensure_ascii = False)
-    # print(myjson)
-    if parsed_xml["response"]["header"]["resultCode"] == "00":
-        result = []
-        itemsList = parsed_xml["response"]["body"]["items"]
-        if itemsList is None:
-            return None
-        items = itemsList['item']
-        if type(items) is dict:
-            temp = {}
-            temp['title'] = items['progrmSj']
-            temp['progrmRegistNo'] = items['progrmRegistNo']
-            result.append(temp)
-
-        for item in items:
-            temp = {}
-            title = item.get('progrmSj')
-            # 놀랍게도 장소 정보를 제공하지 않아, 등록번호로 검색해야 한다
-            # 하지만 API call 개수가 너무 많으면 로딩이 느려지므로 일단은 장소 정보 없이 제공
-            # 향후 필요할 경우 callByRegistNo 함수를 이용해 장소 정보를 가져옴
-            progrmRegistNo = item.get('progrmRegistNo')
-
-            temp['title'] = title
-            temp['progrmRegistNo'] = progrmRegistNo
-            result.append(temp)
-        return result
-    else:
-        return None
-
-def callByRegistNo(registNo):
-    url = 'http://openapi.1365.go.kr/openapi/service/rest/VolunteerPartcptnService/getVltrPartcptnItem'
-    params ={
-        'serviceKey' : settings.VOL_API_KEY,
-        'progrmRegistNo' : registNo
-    }
-    response = requests.get(url, params=params)
-    parsed_xml = xmltodict.parse(response.text)
-    # myjson = json.dumps(parsed_xml,ensure_ascii = False)
-    # print(myjson)
-
-    # print(list(parsed_xml['response'].keys()))
-
-    if parsed_xml["response"]["header"]["resultCode"] == "00":
-        tempVarForNoneCheck = parsed_xml["response"]["body"]["items"]
-        if tempVarForNoneCheck is None:
-            return None
-        item = tempVarForNoneCheck["item"]
-
-        temp = {}
-
-        # 날짜와 시간 값 먼저 처리하기
-        actStartDate = item.get('progrmBgnde')
-        actStartTime = item.get('actBeginTm')
-        # print(f"actStartDate: {actStartDate}, actStartTime: {actStartTime}")
-        actEndDate = item.get('progrmEndde')
-        actEndTime = item.get('actEndTm')
-        # print(f"actEndDate: {actEndDate}, actEndTime: {actEndTime}")
-        actStart = actStartDate[0:4] + '/' + actStartDate[4:6] + '/' + actStartDate[6:8] + '-' + actStartTime + ':00:00'
-        actEnd = actEndDate[0:4] + '/' + actEndDate[4:6] + '/' + actEndDate[6:8] + '-' + actEndTime + ':00:00'
-        tempRecruitStart = item.get('noticeBgnde')
-        tempRecruitEnd = item.get('noticeEndde')
-        recruitStart = tempRecruitStart[0:4] + '/' + tempRecruitStart[4:6] + '/' + tempRecruitStart[6:8]
-        recruitEnd = tempRecruitEnd[0:4] + '/' + tempRecruitEnd[4:6] + '/' + tempRecruitEnd[6:8]
-
-        # 값 가져오기
-        temp['title'] = item.get('progrmSj')
-        temp['recruitStatusNm'] = item.get('progrmSttusSe')
-        temp['actStart'] = actStart
-        temp['actEnd'] = actEnd
-        temp['place'] = item.get('actPlace')
-        temp['adultAble'] = item.get('adultPosblAt')
-        temp['teenAble'] = item.get('yngbgsPosblAt')
-        temp['recruitStart'] = recruitStart
-        temp['recruitEnd'] = recruitEnd
-        temp['recruitInstitute'] = item.get('mnnstNm')
-        temp['registerInstitute'] = item.get('nanmmbyNm')
-        temp['maxPerson'] = item.get('rcritNmpr')
-        temp['content']= item.get('progrmCn')
-        temp['progrmRegistNo'] = registNo
-        temp['tagName']= item.get('srvcClCode')
-
-        return temp
-    else:
-        return None
+def get_cheer_recommend():
+    interactions = Program_Interaction.objects.filter(cheered=True).annotate(cheer_count=Count('cheered')).order_by('-cheer_count')
+    progrmList = list(interactions.values_list('progrmRegistNo', flat=True))
+    
+    data = []
+    for program in progrmList[:4]:
+        p_data = callByRegistNo(program)
+        program_dto_data = ProgramDto(tagName=p_data['tagName'], title=p_data['title'], registerInstitute=p_data['registerInstitute'], \
+                                        recruitStart=p_data['recruitStart'], recruitEnd=p_data['recruitEnd'], actStart=p_data['actStart'], actEnd=p_data['actEnd'])
+        data.append(program_dto_data.to_json())
+    return ResponseDto(status=200, data=data, msg=message['PrgrmRecommendCheer'])

--- a/program/service.py
+++ b/program/service.py
@@ -3,6 +3,7 @@ import xmltodict
 from django.conf import settings
 from django.http import JsonResponse
 from user.models import User
+from django.db.models import Count
 
 from .response import *
 from .models import *
@@ -177,10 +178,11 @@ def callByRegistNo(registNo):
         temp['recruitStart'] = recruitStart
         temp['recruitEnd'] = recruitEnd
         temp['recruitInstitute'] = item.get('mnnstNm')
-        temp['registerInstiute'] = item.get('nanmmbyNm')
+        temp['registerInstitute'] = item.get('nanmmbyNm')
         temp['maxPerson'] = item.get('rcritNmpr')
         temp['content']= item.get('progrmCn')
         temp['progrmRegistNo'] = registNo
+        temp['tagName']= item.get('srvcClCode')
 
         return temp
     else:

--- a/program/urls.py
+++ b/program/urls.py
@@ -4,6 +4,8 @@ from .views import *
 urlpatterns = [
     path('', PrgmInteractUpdateView.as_view()),
     
+    path('recommend/cheer/', PrgmRecommendCheeringView.as_view()),
+    
     path('cheered/', CheeredGetView.as_view()),
     path('participated/', ParticipatedGetView.as_view()),
     path('clipped/', ClippedGetView.as_view()),

--- a/program/views.py
+++ b/program/views.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from .service import *
 from .response import *
 from .serializers import *
-from .dto import ProgramDto
+from .search_service import *
 
 
 def responseFactory(res: ResponseDto):
@@ -32,23 +32,11 @@ parameter_token = openapi.Parameter(
 
 
 ### 봉사 추천 관련
-from django.db.models import Count
 class PrgmRecommendCheeringView(GenericAPIView):
     permission_classes = []
 
     def get(self, request):
-        interactions = Program_Interaction.objects.filter(cheered=True).annotate(cheer_count=Count('cheered')).order_by('-cheer_count')
-        progrmList = list(interactions.values_list('progrmRegistNo', flat=True))
-        
-        data = []
-        for program in progrmList[:4]:
-            p_data = callByRegistNo(program)
-            # print(p_data, p_data['tagName'])
-            program_dto_data = ProgramDto(tagName=p_data['tagName'], title=p_data['title'], registerInstitute=p_data['registerInstitute'], \
-                                          recruitStart=p_data['recruitStart'], recruitEnd=p_data['recruitEnd'], actStart=p_data['actStart'], actEnd=p_data['actEnd'])
-            data.append(program_dto_data.to_json())
-        
-        res = ResponseDto(status=200, data=data, msg=message['PrgrmRecommendCheer'])
+        res = get_cheer_recommend()
         return responseFactory(res)
 
 

--- a/program/views.py
+++ b/program/views.py
@@ -35,7 +35,14 @@ parameter_token = openapi.Parameter(
 class PrgmRecommendCheeringView(GenericAPIView):
     permission_classes = []
 
+    @swagger_auto_schema(
+        responses= {
+            200: message['PrgrmRecommendCheer']
+        })
     def get(self, request):
+        '''
+            ## 봉사 추천: 응원하기 가장 많은 봉사 4개
+        '''
         res = get_cheer_recommend()
         return responseFactory(res)
 
@@ -48,7 +55,6 @@ class PrgmInteractUpdateView(GenericAPIView):
     
     @swagger_auto_schema(
         manual_parameters = [parameter_token],
-        message = "테스트",
         responses= {
             200: message['PrgmInteractSuccess'],
             400: message['PrgmInteractFail'],
@@ -59,7 +65,8 @@ class PrgmInteractUpdateView(GenericAPIView):
             ## 봉사 스크랩하기/응원하기/내가 한 봉사 저장하기
             - `progrmRegistNo` 필드는 필수입니다
             - `cheered`, `participated`, `clipped` 필드는 필수가 아닙니다.
-            예를 들어 봉사번호 123445를 스크랩하려면 위의 사진처럼 request를 보내시면 됩니다
+            예를 들어 봉사번호 123445를 스크랩하려면 
+            { "progrmRegistNo": "123445", "clipped": "True" }
             - 스크랩 취소는 `"clipped": "False"`로 보내시면 됩니다.
         '''
         request.data['user'] = request.user.id
@@ -78,7 +85,7 @@ class CheeredGetView(GenericAPIView):
         })
     def get(self, request):
         '''
-            ## 응원한 봉사 리스트 조회
+            ## 로그인한 유저가 응원한 봉사 리스트 조회
         '''
         user = request.user
         interations_list = get_interactions_list(user, 'cheered')
@@ -97,7 +104,7 @@ class ParticipatedGetView(GenericAPIView):
         })
     def get(self, request):
         '''
-            ## 참여한 봉사 리스트 조회
+            ## 로그인한 유저가 참여한 봉사 리스트 조회
         '''
         user = request.user
         interations_list = get_interactions_list(user, 'participated')
@@ -116,7 +123,7 @@ class ClippedGetView(GenericAPIView):
         })
     def get(self, request):
         '''
-            ## 스크랩한 봉사 리스트 조회
+            ## 로그인한 유저가 스크랩한 봉사 리스트 조회
         '''
         user = request.user
         interations_list = get_interactions_list(user, 'clipped')
@@ -130,7 +137,7 @@ class SearchKeywordView(APIView):
     @swagger_auto_schema(query_serializer=SearchKeywordSerializer, responses={"200":KeywordResponseSerializer, "404":KeywordResponseSerializer})
     def get(self, request):
         '''
-            ## 키워드로 조회
+            ## 봉사 조회: 키워드로 조회
             - `keyword`: 검색할 키워드
             - `actPlace`: 장소 (필수 필드 아님) Ex. 상도
         '''
@@ -147,7 +154,7 @@ class SearchAreaView(APIView):
     @swagger_auto_schema(query_serializer=SearchAreaSerializer, responses={"200":AreaResponseSerializer, "404":AreaResponseSerializer})
     def get(self, request):
         '''
-            ## 지역으로 조회
+            ## 봉사 조회: 지역으로 조회
             - `keyword`: 지역코드(구군) Ex. 3120000
         '''
         keyword = request.query_params.get('keyword')

--- a/review/views.py
+++ b/review/views.py
@@ -73,8 +73,6 @@ class UserReviewList(GenericAPIView):
             - 필수 필드: images, title, content, is_public, progrmRegistNo
             - rid, writer 등의 필드는 백엔드에서 자동으로 넣습니다
             (현재 이미지는 Swagger로 못 보냄, Postman으로 테스트 가능)
-            - 예시 사진
-            ![image](https://dowadream.s3.ap-northeast-2.amazonaws.com/20230815155225195_captureImg.png)
             - 유저는 봉사 당 하나의 리뷰만 남길 수 있음
             - '내가 한 봉사 목록'에 있는 봉사에만 리뷰를 남길 수 있음
         '''
@@ -91,8 +89,8 @@ class UserReviewList(GenericAPIView):
         })
     def get(self, request):
         '''
-            ## 리뷰 리스트 조회(아직 정렬X)
-            - Default값으로 신규순 정렬해서 모든 리뷰 조회하기: `/review/`
+            ## 리뷰 리스트 조회(신규순으로 정렬)
+            - 모든 리뷰 조회하기: `/review/`
             - 특정 봉사에 대한 리뷰 조회: `/review?progrmRegistNo=xxx`
         '''
         progrmRegistNo = request.GET.get('progrmRegistNo')
@@ -138,8 +136,6 @@ class UserReviewDetail(GenericAPIView):
             - 필수 필드: images, title, content, is_public, progrmRegistNo
             - rid, writer 등의 필드는 백엔드에서 자동으로 넣습니다
             (현재 이미지는 Swagger로 못 보냄, Postman으로 테스트 가능)
-            - 예시 사진
-            ![image](https://dowadream.s3.ap-northeast-2.amazonaws.com/20230815155225195_captureImg.png)
         '''
         review = get_object_or_404(Review, rid=rid)
         self.check_object_permissions(self.request, review) # 인가 체크
@@ -294,7 +290,7 @@ class ReviewCheerView(APIView):
     )
     def post(self, request, rid):
         '''
-            ## 특정 리뷰를 응원하기
+            ## (로그인한 유저가) 특정 리뷰를 응원하기
         '''
         user = request.user
         res = cheer_review(user, rid)
@@ -312,7 +308,7 @@ class ReviewCheerView(APIView):
     )
     def delete(self, request, rid):
         '''
-            ## 특정 리뷰 응원 취소하기
+            ## (로그인한 유저가) 특정 리뷰 응원 취소하기
         '''
         user = request.user
         res = cancel_cheering_review(user, rid)

--- a/user/admin.py
+++ b/user/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
-from .models import User
+from .models import *
 
 admin.site.register(User)
+admin.site.register(User_Region)
+admin.site.register(User_Tag)

--- a/user/jwt_token.py
+++ b/user/jwt_token.py
@@ -2,9 +2,8 @@ from rest_framework_simplejwt.serializers import RefreshToken
 
 
 def make_token(email, accept, user):
-    accept_json = accept.json()
-    accept_json.pop('user', None)
-    
+    # accept_json = accept.json()
+    # accept_json.pop('user', None)
     token = RefreshToken.for_user(user)
     refresh_token = str(token)
     access_token = str(token.access_token)

--- a/user/urls.py
+++ b/user/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import *
 
 urlpatterns = [
-    path('login/', google_login, name='google_login'),
+    # path('login/', google_login, name='google_login'),
     path('callback/', google_callback, name='google_callback'),
     path('login/finish/', GoogleLogin.as_view(), name='google_login_todjango'),
     

--- a/user/views.py
+++ b/user/views.py
@@ -38,10 +38,10 @@ parameter_token = openapi.Parameter(
 
 
 # 구글 로그인
-def google_login(request):
-    scope = "https://www.googleapis.com/auth/userinfo.email "
-    client_id = settings.GOOGLE_CLIENT_ID
-    return redirect(f"https://accounts.google.com/o/oauth2/v2/auth?client_id={client_id}&response_type=code&redirect_uri={GOOGLE_CALLBACK_URI}&scope={scope}")
+# def google_login(request):
+    # scope = "https://www.googleapis.com/auth/userinfo.email "
+    # client_id = settings.GOOGLE_CLIENT_ID
+    # return redirect(f"https://accounts.google.com/o/oauth2/v2/auth?client_id={client_id}&response_type=code&redirect_uri={GOOGLE_CALLBACK_URI}&scope={scope}")
 
 
 # Callback 함수

--- a/user/views.py
+++ b/user/views.py
@@ -128,7 +128,7 @@ class ResolMsgView(GenericAPIView):
         })
     def put(self, request):
         '''
-            ## 다짐메세지 변경
+            ## 유저 다짐메세지 변경
         '''
         res = update_resol_msg(request)
         return responseFactory(res)
@@ -146,7 +146,7 @@ class FightingView(GenericAPIView):
         })
     def post(self, request):
         '''
-            ## 파이팅 1점 올리기
+            ## 로그인한 유저의 파이팅 1점 올리기
         '''
         user = request.user
         res = inc_fighting(user)


### PR DESCRIPTION
## PR Point
<!-- 공유하고 싶은 부분, 작업 내용 등 -->
- program/dto.py 파일 생성함
    - tagName에서 대분류 tag 분류해서 tag에 저장, d-day 계산, string->json 형태로 바꾸기 등의 역할 수행
    - 프론트에서 필요한 필드들(마감까지 남은 일수, 태그 , 제목, 등록기관 ,모집기간(시작-끝),봉사기간(봉사 시작 끝))
- `get_cheer_recommend` 함수 추가: cheered 항목이 True인 튜플 개수를 세고, 상위 4개를 반환


## Screenshot
![image](https://github.com/DowaDream/DowaDream-Server/assets/71963320/23c777f9-34f4-41fb-8344-907bb8c0dccb)


## Issue
- Resolved: #42 


## Etc
- Access token 유효기간 3일로 늘렸습니다
- 검색 관련 api는 search_service.py 파일로 분리했습니다

+ 이번에 장고 Queryset에 대해 다시 공부해보면서 블로그에 정리글 올려봤습니다,, annotate 궁금하면 한번 읽어보기
https://so-ssso.tistory.com/51