### PR TITLE
[Fix] 이미지 필드를 넣지 않아도 오류 생기지 않도록

### DIFF
--- a/review/review_service.py
+++ b/review/review_service.py
@@ -8,7 +8,7 @@ from program.search_service import callByRegistNo
 
 
 def post_review(request) -> ResponseDto:
-    images = request.data.getlist('images', [])  # 기본 값을 빈 리스트로 지정
+    images = request.data.getlist('images', []) if 'images' in request.data else ['']
     if len(images[0]) == 0:     # 자동으로 ['']이 들어가기 때문에 한번 더 체크
         images = []
     elif len(images) > 5:


### PR DESCRIPTION
## PR Point
<!-- 공유하고 싶은 부분, 작업 내용 등 -->
- 이미지 필드를 아예 넣지 않으면 오류 발생 -> 자동으로 빈 배열 넣어지도록

## Screenshot
![image](https://github.com/DowaDream/DowaDream-Server/assets/71963320/d3481928-2b1d-4ec2-9acf-ac9c496a35cd)


## Issue
- Resolved: #63 
